### PR TITLE
feat: YAML config support

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,7 +31,7 @@ func (c *Client) Logger() hclog.Logger {
 func Configure(logger hclog.Logger, providerConfig interface{}) (schema.ClientMeta, diag.Diagnostics) {
 	terraformConfig := providerConfig.(*Config)
 
-	if terraformConfig.Config == nil || len(terraformConfig.Config) == 0 {
+	if len(terraformConfig.Config) == 0 {
 		return nil, diag.FromError(errors.New("no config were provided"), diag.USER)
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -37,6 +37,9 @@ func Configure(logger hclog.Logger, providerConfig interface{}) (schema.ClientMe
 
 	var backends = make(map[string]*TerraformBackend)
 	for _, config := range terraformConfig.Config {
+		config := config
+		config.format = terraformConfig.Format()
+
 		logger.Info("creating new backend", "type", config.BackendType)
 		// create backend for each backend config
 		if b, err := NewBackend(&config); err == nil { //nolint:revive

--- a/client/config.go
+++ b/client/config.go
@@ -1,11 +1,23 @@
 package client
 
+import "github.com/cloudquery/cq-provider-sdk/cqproto"
+
 type Config struct {
-	Config []BackendConfigBlock `hcl:"config,block"`
+	Config []BackendConfigBlock `yaml:"config" hcl:"config,block"`
+
+	requestedFormat cqproto.ConfigFormat
 }
 
-func (Config) Example() string {
-	return `configuration {
+func NewConfig(f cqproto.ConfigFormat) *Config {
+	return &Config{
+		requestedFormat: f,
+	}
+}
+
+func (c Config) Example() string {
+	switch c.requestedFormat {
+	case cqproto.ConfigHCL:
+		return `configuration {
 
 	// local backend
 	config "mylocal" {
@@ -22,4 +34,22 @@ func (Config) Example() string {
     }
 }
 `
+	default:
+		return `
+config:
+  - name: mylocal # local backend
+    backend: local
+    path: ./examples/terraform.tfstate
+  - name: myremote # s3 backend
+    backend: s3
+    bucket: tf-states
+    key: terraform.tfstate
+    region: us-east-1
+    role_arn: ""
+`
+	}
+}
+
+func (c Config) Format() cqproto.ConfigFormat {
+	return c.requestedFormat
 }

--- a/client/config.go
+++ b/client/config.go
@@ -1,6 +1,8 @@
 package client
 
-import "github.com/cloudquery/cq-provider-sdk/cqproto"
+import (
+	"github.com/cloudquery/cq-provider-sdk/cqproto"
+)
 
 type Config struct {
 	Config []BackendConfigBlock `yaml:"config" hcl:"config,block"`

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.38.61
-	github.com/cloudquery/cq-provider-sdk v0.11.4
+	github.com/cloudquery/cq-provider-sdk v0.12.0
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/hashicorp/go-hclog v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.38.61
-	github.com/cloudquery/cq-provider-sdk v0.12.0
+	github.com/cloudquery/cq-provider-sdk v0.12.1
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/hashicorp/go-hclog v1.2.1
@@ -17,6 +17,8 @@ require (
 	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 	google.golang.org/genproto v0.0.0-20220314164441-57ef72a4c106 // indirect
 )
+
+require gopkg.in/yaml.v3 v3.0.1
 
 require (
 	github.com/BurntSushi/toml v1.0.0 // indirect
@@ -81,6 +83,5 @@ require (
 	google.golang.org/grpc v1.45.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.3.0-0.dev.0.20220306074811-23e1086441d2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
-github.com/cloudquery/cq-provider-sdk v0.12.0 h1:S3AAkxmXhoGwvn7E77GmcOzkIFAxOjXEhPr+F0jW+Pg=
-github.com/cloudquery/cq-provider-sdk v0.12.0/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
+github.com/cloudquery/cq-provider-sdk v0.12.1 h1:Y4/VWjb/HLRX1pUoA7H82JoEu5mizNCDlfIeLGXOXSA=
+github.com/cloudquery/cq-provider-sdk v0.12.1/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
-github.com/cloudquery/cq-provider-sdk v0.11.4 h1:/y/AB+/mKRGFoc0rLin3KRtfqc5eAooYjqdltrsGi8I=
-github.com/cloudquery/cq-provider-sdk v0.11.4/go.mod h1:q6hYy9S+XtKG8cyOiLG5gqSIkXEJ72MHQ316zW6DMiA=
+github.com/cloudquery/cq-provider-sdk v0.12.0 h1:S3AAkxmXhoGwvn7E77GmcOzkIFAxOjXEhPr+F0jW+Pg=
+github.com/cloudquery/cq-provider-sdk v0.12.0/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/resources/provider.go
+++ b/resources/provider.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/cloudquery/cq-provider-sdk/provider"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 	"github.com/cloudquery/cq-provider-terraform/client"
@@ -13,8 +14,8 @@ func Provider() *provider.Provider {
 		ResourceMap: map[string]*schema.Table{
 			"tf.data": TFData(),
 		},
-		Config: func() provider.Config {
-			return &client.Config{}
+		Config: func(f cqproto.ConfigFormat) provider.Config {
+			return client.NewConfig(f)
 		},
 	}
 }


### PR DESCRIPTION
to go with https://github.com/cloudquery/cq-provider-sdk/pull/332 and https://github.com/cloudquery/cloudquery/pull/887

`go run main.go init terraform --config config.yml` creates this:
```yaml
cloudquery:
    providers:
        - name: terraform
          version: latest
    connection:
        type: postgres
        username: postgres
        password: pass
        host: localhost
        port: 5432
        database: postgres
        sslmode: disable
providers:
    # provider configurations
    - name: terraform
      # config:
      #   - name: mylocal # local backend
      #     backend: local
      #     path: ./examples/terraform.tfstate
      #   - name: myremote # s3 backend
      #     backend: s3
      #     bucket: tf-states
      #     key: terraform.tfstate
      #     region: us-east-1
      #     role_arn: ""
      #  
      # list of resources to fetch
      resources:
        - tf.data
```